### PR TITLE
Link data to odc website

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,8 +93,6 @@ jobs:
           echo "NEXT_PUBLIC_BASE_PATH=$BASE_PATH" >> .env.local
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
-      - name: Static HTML export with Next.js
-        run: ${{ steps.detect-package-manager.outputs.runner }} next export
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -1,28 +1,41 @@
 {
   "index": {
-    "title": "Home",
+    "title" : "Home",
+    "type": "page",
+    "display":"hidden",
     "theme": {
       "layout": "full",
       "breadcrumb": false,
       "footer": true,
       "sidebar": false,
-      "toc": true,
+      "toc": false,
       "pagination": false
     }
   },
   "about-us": {
     "title": "About us",
-    "type": "page"
+    "type": "page",
+    "display":"hidden"
   },
   "blog": {
     "title": "Blog",
     "type": "page",
+    "display":"hidden",
     "theme": {
       "toc": false,
       "pagination": true,
       "breadcrumb": false
-
     }
+  },
+  "data":{
+    "title": "Data",
+    "type": "page",
+    "href":"https://data.opendatacommunity.org",
+    "newWindow": true
+  },
+  "docs": {
+    "title": "Docs",
+    "type": "page"
   },
   "hackathon": {
     "title": "Hackathon",
@@ -36,10 +49,6 @@
       "pagination": false
     }
   },
-  "docs": {
-    "title": "Docs",
-    "type": "page"
-  },
   "projects":{
     "title":"Projects",
     "type":"page",
@@ -52,11 +61,24 @@
       "pagination": false
     }
   },
-  "forum":{
-    "title": "Forum",
-    "type": "page",
-    "href":"https://forum.opendatacommunity.org/",
-    "newWindow": true
+  "more": {
+    "title": "More",
+    "type": "menu",
+    "items":{
+      "about-us":{
+        "title":"About us",
+        "href":"/about-us"
+      },
+      "blog":{
+        "title":"Blog",
+        "href":"/blog/data-builder-hackathon"
+      },
+      "forum":{
+        "title": "Forum",
+        "href":"https://forum.opendatacommunity.org",
+        "newWindow": true
+      }
+    }
   }
   
 }


### PR DESCRIPTION
Add a link to data website in the navbar.
Fix a warning caused by deployment file.
You can see the changes here:  https://hebb00.github.io
