### PR TITLE
refactor: remove hackathon navigation link

### DIFF
--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -45,18 +45,6 @@
     "title": "Docs",
     "type": "page"
   },
-  "hackathon": {
-    "title": "Hackathon",
-    "type": "page",
-    "theme": {
-      "layout": "full",
-      "breadcrumb": false,
-      "footer": true,
-      "sidebar": false,
-      "toc": false,
-      "pagination": false
-    }
-  },
   "projects":{
     "title":"Projects",
     "type":"page",

--- a/pages/hackathon.mdx
+++ b/pages/hackathon.mdx
@@ -1,7 +1,0 @@
----
-"title" : "Regen Rangers Hackathon"
-"description": "Use data analysis for good - Win $40k in bounties"
----
-import Hackathon from "/src/hackathon.tsx"
-
-<Hackathon />


### PR DESCRIPTION
Remove the last hackathon link from the navigation bar
you can check the updates here: https://hebb00.github.io/